### PR TITLE
Update pipeline with builder container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-# Using a public base image, can be improved by using `FROM scratch` and adding Alpine rootfs e.g. https://github.com/gliderlabs/docker-alpine/tree/2bfe6510ee31d86cfeb2f37587f4cf866f28ffbc/builder
-FROM alpine:latest
+FROM alpine:latest as base
 RUN adduser -D --system java && \
 	apk add --update --no-cache openjdk8-jre
 USER java
+
+FROM base as builder
+USER root
+RUN apk add --no-cache maven openjdk8 procps

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,20 @@ IMAGE_NAME ?= nexus:18443/java-base
 # PUBLIC TARGETS #
 ##################
 dockerBuild:
-	docker build -t $(IMAGE_NAME):$(BUILD_VERSION) .
+	docker build --target base -t $(IMAGE_NAME):$(BUILD_VERSION) .
+	docker build --target builder -t $(IMAGE_NAME)-builder:$(BUILD_VERSION) .
 
 dockerPush:
 	docker push $(IMAGE_NAME):$(BUILD_VERSION)
+	docker push $(IMAGE_NAME)-builder:$(BUILD_VERSION)
 
 dockerPushLatest:
 	docker pull $(IMAGE_NAME):$(BUILD_VERSION)
 	docker tag $(IMAGE_NAME):$(BUILD_VERSION) $(IMAGE_NAME):latest
 	docker push $(IMAGE_NAME):latest
+	docker pull $(IMAGE_NAME)-builder:$(BUILD_VERSION)
+	docker tag $(IMAGE_NAME)-builder:$(BUILD_VERSION) $(IMAGE_NAME)-builder:latest
+	docker push $(IMAGE_NAME)-builder:latest
 
 nexusLogin:
 	echo "$(NEXUS_PASSWORD)" | docker login https://nexus:18443 -u admin --password-stdin

--- a/README.md
+++ b/README.md
@@ -7,24 +7,42 @@ This image aims to provide a secure and hardened environment to run Java applica
 Features:
   * Jenkins pipeline for building the Docker image
   * Automatic builds for the latest security updates
+  * Builder container for [multistage] or [builder container pattern]
   * Vulnerability scanning
   * A minimal base image to reduce attack surface and external dependencies
   * Uses the [3 Musketeers] methodology (Docker, docker-compose and make) for a simple and portable pipeline
 
 [3 Musketeers]: https://3musketeers.io/
+[multistage]: https://docs.docker.com/develop/develop-images/multistage-build/
+[builder container pattern]: https://medium.com/@alexeiled/docker-pattern-the-build-container-b0d0e86ad601
 
 ## How To Use?
 
-In your downstream application, point your Dockerfile to the `nexus:18443/java-base:latest`, and update your Jenkins pipeline to build your application whenever there is an update to it.
+Your Docker container will be built with a two-stage process: the first stage builds the JAR file, the second stage builds the Docker image.
+
+In your downstream application, your initial stage will use `nexus:18443/java-base-builder:latest` and is responsible for outputting a JAR file using maven.
+
+A second stage will be based on `nexus:18443/java-base:latest` and consume this JAR file, creating a Docker image that is deployed to all environments as an immutable artifact. This image will be lightweight and contains no build tools or other unnecessary dependencies.
+
+Your downstream app will be automatically triggered whenever this Docker image is rebuilt, ensuring it always has the latest security updates.
 
 ## Examples
 
 Dockerfile:
 ```Dockerfile
+FROM nexus:18443/java-base-builder:latest as builder
+WORKDIR /srv/app
+
+# download dependencies first to cache them in a Docker layer, only rebuilds if pom.xml is modified
+COPY pom.xml /srv/app/
+RUN mvn verify clean --fail-never
+
+COPY . /srv/app
+RUN mvn clean install
+
 FROM nexus:18443/java-base:latest
 VOLUME /tmp
-ARG JAR_FILE
-COPY target/cicd-demo-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=builder /srv/app/target/cicd-demo-0.0.1-SNAPSHOT.jar app.jar
 ENTRYPOINT [ "java","-Djava.security.egd=file:/dev/./unrandom","-jar","/app.jar" ]
 ```
 


### PR DESCRIPTION
  * Use a multistage Dockerfile to ensure that our builder container is
always building for the same version of Java that our base image is
using
  * Update make targets to build and push the builder image
  * Update README to elaborate on why a builder image and how to use it
  * add `procps` container as Surefire tests crash without it
https://issues.apache.org/jira/browse/SUREFIRE-1422